### PR TITLE
Add demo student/admin credentials and password-based login on LoginPage

### DIFF
--- a/plannit-muj/src/Pages/LoginPage.tsx
+++ b/plannit-muj/src/Pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
-import { Mail } from "lucide-react";
+import { Lock, Mail } from "lucide-react";
 import { Button } from "../../components/ui/Button";
 import { Card } from "../../components/ui/Card";
 import toast from "react-hot-toast";
@@ -11,7 +11,27 @@ const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const { login } = useAuthStore();
 
+  const demoCredentials = [
+    {
+      email: "student@jaipur.manipal.edu",
+      password: "Student@123",
+      name: "Demo Student",
+      role: "student" as const,
+      department: "Computer Science",
+      year: "3rd",
+    },
+    {
+      email: "admin@plannitmuj.com",
+      password: "Admin@123",
+      name: "Campus Admin",
+      role: "admin" as const,
+      department: "Student Affairs",
+      year: "",
+    },
+  ];
+
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -26,15 +46,23 @@ const LoginPage: React.FC = () => {
         return;
       }
 
-      const displayName = trimmedEmail.split("@")[0] || "User";
+      const matchedUser = demoCredentials.find(
+        (credential) =>
+          credential.email === trimmedEmail && credential.password === password
+      );
+
+      if (!matchedUser) {
+        toast.error("Invalid email or password. Please use the demo credentials.");
+        return;
+      }
 
       login({
-        id: `email-${btoa(trimmedEmail)}`,
-        name: displayName,
+        id: `email-${btoa(matchedUser.email)}`,
+        name: matchedUser.name,
         email: trimmedEmail,
-        role: "student",
-        department: "",
-        year: "",
+        role: matchedUser.role,
+        department: matchedUser.department,
+        year: matchedUser.year,
         points: 0,
         createdAt: new Date(),
       });
@@ -76,14 +104,37 @@ const LoginPage: React.FC = () => {
               </div>
             </div>
 
+            <div>
+              <label className="block mb-2 text-sm font-medium">Password</label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-3 text-gray-400" />
+                <input
+                  type="password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full pl-10 pr-4 py-3 border rounded-lg"
+                  placeholder="Enter password"
+                />
+              </div>
+            </div>
+
             <Button className="w-full" type="submit" isLoading={loading}>
               {loading ? "Signing in..." : "Sign In"}
             </Button>
           </form>
 
-          <p className="text-center mt-6 text-sm text-gray-600 dark:text-gray-300">
-            Sign up is temporarily disabled.
-          </p>
+          <div className="mt-6 rounded-lg border border-blue-100 bg-blue-50 p-4 text-sm text-blue-900">
+            <p className="font-semibold mb-2">Demo login credentials</p>
+            <p>
+              <span className="font-medium">Student:</span>{" "}
+              student@jaipur.manipal.edu / Student@123
+            </p>
+            <p>
+              <span className="font-medium">Admin:</span> admin@plannitmuj.com /
+              Admin@123
+            </p>
+          </div>
         </Card>
       </motion.div>
     </div>


### PR DESCRIPTION
### Motivation

- Provide working login credentials for both student and admin users so the app can be tested without a backend auth provider. 
- Ensure the login flow can create role-aware session state instead of defaulting every user to `student`.

### Description

- Added a `demoCredentials` array with two demo accounts (student + admin) and imported the `Lock` icon for the password field. 
- Added a password input and local `password` state to the login form and UI. 
- Implemented validation to match the entered email/password pair against `demoCredentials` and populate the session with role-specific fields (`role`, `department`, `year`) when a match is found. 
- Rendered visible demo credential hints on the login page to make testing straightforward. 

### Testing

- Ran `npm run build`, which completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and manually validated the updated login UI and behavior, including capturing a screenshot via a Playwright script; validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699588f917c88327977696cf4eed26d8)